### PR TITLE
Add RolePermissionSeeder to pre-populate role permissions

### DIFF
--- a/src/features/auth/hooks/useAuth.js
+++ b/src/features/auth/hooks/useAuth.js
@@ -8,6 +8,13 @@ import {
   setUser 
 } from '../authSlice';
 import authService from '../services/authService';
+import { ROLES } from '../../../shared/utils/permissions';
+
+const roleMap = {
+  1: ROLES.SUPER_ADMIN,
+  2: ROLES.ADMIN,
+  3: ROLES.STAFF,
+};
 
 export const useAuth = () => {
   const dispatch = useDispatch();
@@ -142,7 +149,7 @@ export const useAuth = () => {
     loading,
     error,
     accessToken,
-    userRole: user?.role?.role_name,
+    userRole: user ? roleMap[user.role_id] : null,
     login,
     logout,
     getCurrentUser,

--- a/src/features/brands/hooks/useBrands.js
+++ b/src/features/brands/hooks/useBrands.js
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import { toast } from 'sonner';
 import { brandService } from '../services';
 import {
@@ -9,8 +9,9 @@ import {
 } from '../utils';
 
 export const useBrands = () => {
-  const [brands, setBrands] = useState(() => brandService.fetchBrands());
-  const isLoading = false;
+  const [brands, setBrands] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   // Dialog states
   const [isFormOpen, setIsFormOpen] = useState(false);
@@ -22,6 +23,23 @@ export const useBrands = () => {
   // Form state
   const [formData, setFormData] = useState(INITIAL_FORM_STATE);
   const [formErrors, setFormErrors] = useState(INITIAL_FORM_ERRORS);
+
+  const fetchBrands = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    const { data, success, error: fetchError } = await brandService.fetchBrands();
+    if (success) {
+      setBrands(data);
+    } else {
+      setError(fetchError);
+      toast.error(UI_TEXT.TOAST_FETCH_ERROR);
+    }
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    fetchBrands();
+  }, [fetchBrands]);
 
   const resetForm = useCallback(() => {
     setFormData(INITIAL_FORM_STATE);
@@ -58,7 +76,7 @@ export const useBrands = () => {
     }
   }, [formErrors]);
 
-  const handleSubmit = useCallback(() => {
+  const handleSubmit = async () => {
     const { isValid, errors } = validateBrandForm(formData, brands, selectedBrand?.id);
     if (!isValid) {
       setFormErrors(errors);
@@ -67,20 +85,26 @@ export const useBrands = () => {
     }
 
     if (formMode === 'create') {
-      brandService.createBrand(formData);
-      setBrands(brandService.fetchBrands());
-      closeFormDialog();
-      toast.success(UI_TEXT.TOAST_CREATE);
+      const { success, error: createError } = await brandService.createBrand(formData);
+      if (success) {
+        await fetchBrands();
+        closeFormDialog();
+        toast.success(UI_TEXT.TOAST_CREATE);
+      } else {
+        toast.error(createError || UI_TEXT.TOAST_CREATE_ERROR);
+      }
     } else {
-      const updated = brandService.updateBrand(selectedBrand.id, formData);
-      if (updated) {
-        setBrands(brandService.fetchBrands());
+      const { success, error: updateError } = await brandService.updateBrand(selectedBrand.id, formData);
+      if (success) {
+        await fetchBrands();
         closeFormDialog();
         toast.success(UI_TEXT.TOAST_UPDATE);
+      } else {
+        toast.error(updateError || UI_TEXT.TOAST_UPDATE_ERROR);
       }
     }
     return true;
-  }, [formData, brands, selectedBrand, formMode, closeFormDialog]);
+  };
 
   const openDeleteDialog = useCallback((brand) => {
     setBrandToDelete(brand);
@@ -92,22 +116,25 @@ export const useBrands = () => {
     setIsDeleteOpen(false);
   }, []);
 
-  const handleDelete = useCallback(() => {
+  const handleDelete = async () => {
     if (!brandToDelete) return false;
-    const success = brandService.deleteBrand(brandToDelete.id);
+    const { success, error: deleteError } = await brandService.deleteBrand(brandToDelete.id);
     if (success) {
-      setBrands(brandService.fetchBrands());
+      await fetchBrands();
       closeDeleteDialog();
       toast.success(UI_TEXT.TOAST_DELETE);
       return true;
+    } else {
+      toast.error(deleteError || UI_TEXT.TOAST_DELETE_ERROR);
     }
     return false;
-  }, [brandToDelete, closeDeleteDialog]);
+  };
 
   return {
     // Data
     brands,
     isLoading,
+    error,
 
     // Form state
     formData,

--- a/src/shared/components/layout/MainLayout.jsx
+++ b/src/shared/components/layout/MainLayout.jsx
@@ -3,12 +3,14 @@ import Sidebar from './Sidebar';
 import Header from './Header'; // Import the new Header
 import SidebarItem from './SidebarItem';
 import MobileMenuButton from './MobileMenuButton';
+import { useAuth } from '../../../features/auth';
 import { useFilteredMenu } from '../../hooks/useFilteredMenu';
 import { useMobileMenu } from '../../hooks/useMobileMenu';
 import logo from '../../../assets/logo-dark.png';
 
 const MainLayout = () => {
   const location = useLocation();
+  const { user, userRole } = useAuth();
   const filteredMenu = useFilteredMenu();
   const { isMobile, isMenuOpen, closeMenu, toggleMenu } = useMobileMenu();
 


### PR DESCRIPTION
## What's new in this PR

### Quick Setup

- Run `php artisan db:seed` to populate the database with the new `RolePermissionSeeder`.

### TL;DR

This PR introduces a new database seeder, `RolePermissionSeeder`, to automatically assign all permissions to the `superadmin` role. This eliminates the need for manual permission assignment after setting up the application.

### Summary

Previously, new installations of the application required a manual API call to grant the `superadmin` role the necessary permissions to access all modules. This PR automates this process by introducing a new database seeder that runs after the `RoleSeeder` and `PermissionSeeder`.

### Key Features

-   **`RolePermissionSeeder`:** A new seeder that assigns all existing permissions to the `superadmin` role.
-   **Updated `DatabaseSeeder`:** The `DatabaseSeeder` is updated to call the new `RolePermissionSeeder`, ensuring that the permissions are seeded automatically.

### Technical Changes

-   Created `database/seeders/RolePermissionSeeder.php`.
-   Updated `database/seeders/DatabaseSeeder.php` to call the new seeder.

### Checklist

-   [x] The `superadmin` role now has all permissions by default.
-   [x] Manual permission assignment for the `superadmin` role is no longer necessary.
-   [x] The application is in a consistent state after running `php artisan db:seed`.
