### PR TITLE
remove the console.log debugging

### DIFF
--- a/src/features/roles/RolesPage.jsx
+++ b/src/features/roles/RolesPage.jsx
@@ -12,7 +12,7 @@ import {
 import { PERMISSION_MODULES } from './utils';
 
 const RolesPage = () => {
-  const { user } = useAuth();
+  const { userRole } = useAuth();
   const {
     roles,
     isLoading,
@@ -36,7 +36,7 @@ const RolesPage = () => {
     getUserCount,
   } = useRoles();
 
-  const normalizedRole = user?.role?.toLowerCase();
+  const normalizedRole = userRole?.toLowerCase();
   const isAuthorized = normalizedRole === 'admin' || normalizedRole === 'superadmin';
 
   if (!isAuthorized) {


### PR DESCRIPTION
What's new in this PR:

- Quick Setup
    - No specific setup needed. This is a frontend-only fix.

- TL;DR
    - Fixed an issue on the Roles page where users were incorrectly shown an "Access denied" message due to the `user.role` property being `undefined` after login. The authorization logic now correctly uses the `userRole` provided by the `useAuth` hook.

- Summary
    - This PR addresses a bug where users with administrative roles (admin, superadmin) were unable to access the Roles management page immediately after logging in. The root cause was that the frontend was attempting to access `user.role.name` for authorization, but the `user.role` object was `undefined`. This was due to the backend's `/login` endpoint not returning the full `role` object, and the subsequent `/me` endpoint not eager loading the `role` relationship by default (as per the decision not to modify the backend).

- Key Features
    - Ensures correct authorization for the Roles page.
    - Prevents "Access denied" message for authorized users on initial load of the Roles page.

- Technical Changes
    - **`pacadaworkz-motomedic-ims-app/src/features/roles/RolesPage.jsx`**:
        - Modified the destructuring of the `useAuth` hook to retrieve `userRole` instead of `user`.
        - Updated the authorization logic to use `userRole?.toLowerCase()` for role normalization, directly utilizing the pre-mapped role string from the `useAuth` hook. This circumvents the issue of `user.role` being `undefined` and ensures proper role identification on the frontend.

- Checklist
    - [x] Tested login with an 'admin' user and verified access to the Roles page.
    - [x] Tested login with a 'superadmin' user and verified access to the Roles page.
    - [x] Tested login with a non-admin user and verified "Access denied" message.
    - [x] Confirmed no backend changes were introduced.